### PR TITLE
feat(import_devices): support devices that don't use ids.id

### DIFF
--- a/espq.py
+++ b/espq.py
@@ -394,22 +394,22 @@ def import_devices(device_file):
         device_import = json.load(f)
     devices=[]
     for dev in device_import:
-        try:
+        if 'ids' in dev:
             for id_info in dev['ids']:
                 new_dev = deepcopy(dev)
-                for key in new_dev:
-                    if isinstance(new_dev[key], str):
-                        new_dev[key] = sub('%id%',
-                                           id_info['id'],
-                                           new_dev[key])
-                # new_dev['ip_addr'] = id_info['ip_addr']
-                # if 'mac_addr' in id_info:
-                #     new_dev['mac_addr'] = id_info['mac_addr']
-                # Need to add processing of custom device parameters
+                #if the device specific obj has an "id" field
+                if 'id' in id_info:
+                    #replace the "%id%" string in all string properties
+                    for key in new_dev:
+                        if isinstance(new_dev[key], str):
+                            new_dev[key] = sub('%id%',
+                                               id_info['id'],
+                                               new_dev[key])
+                # just copy all the keys over
                 for key in id_info:
                     new_dev[key] = id_info[key]
                 devices.append(device(new_dev))
-        except KeyError:
+        else: # no ids field
             devices.append(device(dev))
     devices = sorted(devices, key=lambda k: k.module)
     return devices


### PR DESCRIPTION
Right now if a device has an ids field, that means that there are multiple devices that are fundimentally the same.
It expects an id field, that it will do replacement on the topic with.

This changes it so it doesn't require you to have the id, you could just set the topic or something.

Also chages from a try/catch to see if the ids field exists to if/else.