### PR TITLE
feat: query IP if not set in config file

### DIFF
--- a/espq.py
+++ b/espq.py
@@ -239,6 +239,16 @@ class device(dict):
         if not os.path.exists(tasmotaPIO) or not cmp(correctPIO, tasmotaPIO):
             copyfile(correctPIO, tasmotaPIO)
 
+        if not 'ip_addr' in self or self.ip_addr == '' or self.ip_addr == None:
+            print('No IP address for this device in the config. Querying device...')
+            self.query_tas_status()
+            if 'ip' in self.reported:
+                print('{name} is online at {ip}'.format(name=self.f_name, ip=self.reported['ip']))
+                self.ip_addr = self.reported['ip']
+            else:
+                print('{f_name} did not respond at {c_topic}. IP address unavailable. Skipping device...'.format(**self))
+                return(False)
+
         os.chdir(tasmota_dir)
         pio_call = 'platformio run -e {environment} -t upload --upload-port {port}'
         if self.flash_mode == 'wifi':

--- a/ip_query.py
+++ b/ip_query.py
@@ -45,6 +45,8 @@ for device in d:
     offline = False
     if not bool(response):
         offline = True
+    if "ip_addr" not in device:
+        device.ip_addr = '';
 
     # Skip printing if the device does not meet filter requirements
     if args.filter == 'update' and (response['tas_version'] == current_version or response['tas_version'] == ''):


### PR DESCRIPTION
I really don't like how query_tas_status works but oh well.
This will query the device for it's IP if it isn't set in the config file.
This means tracking IP addrs in files is optional as long as the device is
online, which it should be to flash anyway.