### PR TITLE
fix: remove query response from device properties

### DIFF
--- a/espq.py
+++ b/espq.py
@@ -103,6 +103,7 @@ class device(dict):
         self.mqtt.on_message = self._on_message
         self.flashed = False 
         self.online = False
+        self.reported = {}
 
     def __getattr__(self, name):
         if name in self:
@@ -359,8 +360,8 @@ class device(dict):
         #  were found
         starttime = datetime.datetime.now()
         while(not _list_all_true(list(map(lambda num: 'status{num}'.format(num=num) in response, tasmota_status_query.keys())))
-                and not _too_old(starttime, loop_time)):
-            self.mqtt.loop(timeout=loop_time)
+                and not _too_old(starttime, 2*loop_time)):
+            self.mqtt.loop(timeout=2*loop_time)
 
         self.mqtt.unsubscribe(s_topic)
         self.mqtt.message_callback_remove(s_topic)

--- a/espq.py
+++ b/espq.py
@@ -295,7 +295,9 @@ class device(dict):
         online_topic = '{t_topic}/INFO2'.format(**self)
         print('{BLUE}Watching for {}{NOCOLOR}'.format(online_topic, **colors))
         self.mqtt.connect(self.mqtt_host)
-        self.mqtt.message_callback_add(online_topic, lambda *args: setattr(self, 'online', True))
+        def fuckPython(*args):
+            online = True;
+        self.mqtt.message_callback_add(online_topic, fuckPython)
         self.mqtt.subscribe(online_topic)
         starttime = datetime.datetime.now()
         while online == False and (datetime.datetime.now() - starttime).total_seconds() < wait_time:

--- a/espq.py
+++ b/espq.py
@@ -131,13 +131,12 @@ class device(dict):
 
         # Flash the right software.
         if self.software == 'tasmota':
-            flashed = self.flash_tasmota()
+            self.flashed = self.flash_tasmota()
         else:
-            flashed = self.flash_custom()
-            self.flashed = flashed # flash.py needs this right now, TODO: remove
+            self.flashed = self.flash_custom()
         # If it flashed correctly, watch for it to come online.
         online = False
-        if flashed == True:
+        if self.flashed == True:
             print(('{GREEN}{f_name} flashed successfully. Waiting for it to '
                    'come back online...{NOCOLOR}'.format(**colors, **self)))
             sleep(1)
@@ -145,11 +144,11 @@ class device(dict):
         else:
             self._handle_result(1)
 
-        if online == False and flashed == True:
+        if online == False and self.flashed == True:
             self._handle_result(2)
         # If it came back online, run any setup commands,
         # and watch for it to come online again.
-        elif flashed == True and online == True:
+        elif self.flashed == True and online == True:
             # Skip commands if there are none.
             if not hasattr(self, 'commands') or self.commands is None or not self.commands:
                 self._handle_result(0)

--- a/flash.py
+++ b/flash.py
@@ -19,7 +19,7 @@ def fmtcols(mylist, cols):
 
 def progress_report(devices):
     """ Print a list of devices and their flashing status """
-    formatted_status = fmtcols(["[{status}] {d}".format(status = 'X' if dev.flashed == True else ' ', d=dev.name) for dev in devices], 3)
+    formatted_status = fmtcols(["[{status}] {d}".format(status = 'X' if (dev.flashed == True and dev.online == True) else ' ', d=dev.name) for dev in devices], 3)
     print(re.sub('\[X\]', '[\033[1;32mX\033[0m]', formatted_status))
     print('=' * cols)
 

--- a/ip_query.py
+++ b/ip_query.py
@@ -41,11 +41,15 @@ d = espq.import_devices(args.deviceFile)
 name_len = max([len(dev.name) for dev in d])
 
 for device in d:
-    network_response = device.query_tas_status(espq.network_attr)
-    firmware_response = device.query_tas_status(espq.firmware_attr)
+    response = device.query_tas_status()
+    print(response);
+    exit(1);
+    if "ip_addr" not in device:
+        device.ip_addr = '';
+
 
     offline = False;
-    if not bool(network_response) or not bool(firmware_response):
+    if not bool(response):
         offline = True;
 
     # Skip printing if the device does not meet filter requirements


### PR DESCRIPTION
query_tas_status and online/flashing checks put stuff into the device object.
This is bad and not necessary except for flashed which flash.py uses to show how much is done.
Now query_tas_status returns a dict of stuff instead of assigning it to device.

Flashing isn't tested yet.

This will cause conflicts with the PR I just did to make ip_addr optional, so lets work out this one first then come back to that one.
I put it in "draft" state cause it's not tested fully but I still want your opinions on it.