### PR TITLE
fix(pio override): Override tasmota port selection

### DIFF
--- a/platformio_override.ini
+++ b/platformio_override.ini
@@ -24,8 +24,10 @@ build_flags               = ${core_active.build_flags}
 
 [env:tasmota-serial]
 extends = env:tasmota
+upload_port = *
 extra_scripts             = ${scripts_defaults.extra_scripts}
                             pio/obj-dump.py
+
 [env:tasmota-wifi]
 extends = env:tasmota
 extra_scripts             = ${scripts_defaults.extra_scripts}


### PR DESCRIPTION
Tasmota hardcodes COM5 for upload_port, which is less than useful.
* seems to be autodetect
