### PR TITLE
fix(templates): remove hass base topic

### DIFF
--- a/hass_templates/3-way-tuya-light-switch.py
+++ b/hass_templates/3-way-tuya-light-switch.py
@@ -10,10 +10,10 @@ import generic
 
 light = """- platform: mqtt
   name: '{f_name}'
-  state_topic: 'stat/{base_topic}/{topic}/POWER1'
-  command_topic: 'cmnd/{base_topic}/{topic}/EVENT'
-  json_attributes_topic: 'tele/{base_topic}/{topic}/STATE'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  state_topic: 'stat/{topic}/POWER1'
+  command_topic: 'cmnd/{topic}/EVENT'
+  json_attributes_topic: 'tele/{topic}/STATE'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
   payload_on: 'ON'

--- a/hass_templates/3-way-tuya-switch.py
+++ b/hass_templates/3-way-tuya-switch.py
@@ -10,10 +10,10 @@ import generic
 
 switch = """- platform: mqtt
   name: '{f_name}'
-  state_topic: 'stat/{base_topic}/{topic}/POWER1'
-  command_topic: 'cmnd/{base_topic}/{topic}/EVENT'
-  json_attributes_topic: 'tele/{base_topic}/{topic}/STATE'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  state_topic: 'stat/{topic}/POWER1'
+  command_topic: 'cmnd/{topic}/EVENT'
+  json_attributes_topic: 'tele/{topic}/STATE'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
   payload_on: 'ON'

--- a/hass_templates/generic.py
+++ b/hass_templates/generic.py
@@ -4,9 +4,9 @@
 
 sensor = """- platform: mqtt
   name: '{f_name}'
-  state_topic: 'stat/{base_topic}/{topic}/SENSOR'
-  json_attributes_topic: 'tele/{base_topic}/{topic}/STATE'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  state_topic: 'stat/{topic}/SENSOR'
+  json_attributes_topic: 'tele/{topic}/STATE'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 """

--- a/hass_templates/light.py
+++ b/hass_templates/light.py
@@ -5,10 +5,10 @@ import generic
 
 light = """- platform: mqtt
   name: '{f_name}'
-  state_topic: 'stat/{base_topic}/{topic}/POWER'
-  command_topic: 'cmnd/{base_topic}/{topic}/POWER'
-  json_attributes_topic: 'tele/{base_topic}/{topic}/STATE'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  state_topic: 'stat/{topic}/POWER'
+  command_topic: 'cmnd/{topic}/POWER'
+  json_attributes_topic: 'tele/{topic}/STATE'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
   payload_on: 'ON'

--- a/hass_templates/light_bn.py
+++ b/hass_templates/light_bn.py
@@ -5,16 +5,16 @@ import generic
 
 light = """- platform: mqtt
   name: '{f_name}'
-  state_topic: 'stat/{base_topic}/{topic}/POWER'
-  command_topic: 'cmnd/{base_topic}/{topic}/POWER'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  state_topic: 'stat/{topic}/POWER'
+  command_topic: 'cmnd/{topic}/POWER'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
   payload_on: 'ON'
   payload_off: 'OFF'
   brightness_scale: 50
-  brightness_command_topic: 'cmnd/{base_topic}/{topic}/Dimmer'
-  brightness_state_topic: 'stat/{base_topic}/{topic}/RESULT'
+  brightness_command_topic: 'cmnd/{topic}/Dimmer'
+  brightness_state_topic: 'stat/{topic}/RESULT'
   brightness_value_template: '{{{{value_json.Dimmer}}}}'
 """
 

--- a/hass_templates/light_rgb.py
+++ b/hass_templates/light_rgb.py
@@ -8,18 +8,18 @@ light = """- platform: mqtt
   effect_list:
     - 2
     - 3
-  state_topic: "stat/{base_topic}/{topic}/RESULT"
-  command_topic: "cmnd/{base_topic}/{topic}/POWER"
-  json_attributes_topic: 'tele/{base_topic}/{topic}/STATE'
-  availability_topic: "tele/{base_topic}/{topic}/LWT"
-  brightness_state_topic: "stat/{base_topic}/{topic}/RESULT"
-  brightness_command_topic: "cmnd/{base_topic}/{topic}/Dimmer"
+  state_topic: "stat/{topic}/RESULT"
+  command_topic: "cmnd/{topic}/POWER"
+  json_attributes_topic: 'tele/{topic}/STATE'
+  availability_topic: "tele/{topic}/LWT"
+  brightness_state_topic: "stat/{topic}/RESULT"
+  brightness_command_topic: "cmnd/{topic}/Dimmer"
   brightness_scale: 100
   rgb_command_template: "{{{{ '%02x%02x%02x00' | format(red, green, blue)}}}}"
-  rgb_state_topic: "stat/{base_topic}/{topic}/RESULT"
-  rgb_command_topic: "cmnd/{base_topic}/{topic}/Color"
-  effect_command_topic: "cmnd/{base_topic}/{topic}/Scheme"
-  effect_state_topic: "stat/{base_topic}/{topic}/RESULT"
+  rgb_state_topic: "stat/{topic}/RESULT"
+  rgb_command_topic: "cmnd/{topic}/Color"
+  effect_command_topic: "cmnd/{topic}/Scheme"
+  effect_state_topic: "stat/{topic}/RESULT"
   state_value_template: >
     {{% if "POWER" in value_json %}}
       {{{{ value_json.POWER }}}}

--- a/hass_templates/light_rgbw.py
+++ b/hass_templates/light_rgbw.py
@@ -8,21 +8,21 @@ light = """- platform: mqtt
   effect_list:
     - 2
     - 3
-  state_topic: "stat/{base_topic}/{topic}/RESULT"
-  command_topic: "cmnd/{base_topic}/{topic}/POWER"
-  json_attributes_topic: 'tele/{base_topic}/{topic}/STATE'
-  availability_topic: "tele/{base_topic}/{topic}/LWT"
-  brightness_state_topic: "stat/{base_topic}/{topic}/RESULT"
-  brightness_command_topic: "cmnd/{base_topic}/{topic}/Dimmer"
+  state_topic: "stat/{topic}/RESULT"
+  command_topic: "cmnd/{topic}/POWER"
+  json_attributes_topic: 'tele/{topic}/STATE'
+  availability_topic: "tele/{topic}/LWT"
+  brightness_state_topic: "stat/{topic}/RESULT"
+  brightness_command_topic: "cmnd/{topic}/Dimmer"
   brightness_scale: 100
   rgb_command_template: "{{{{ '%02x%02x%02x00' | format(red, green, blue)}}}}"
-  rgb_state_topic: "stat/{base_topic}/{topic}/RESULT"
-  rgb_command_topic: "cmnd/{base_topic}/{topic}/Color"
-  white_value_state_topic: "stat/stat/{base_topic}/{topic}/RESULT"
-  white_value_command_topic: "cmnd/{base_topic}/{topic}/channel4"
+  rgb_state_topic: "stat/{topic}/RESULT"
+  rgb_command_topic: "cmnd/{topic}/Color"
+  white_value_state_topic: "stat/stat/{topic}/RESULT"
+  white_value_command_topic: "cmnd/{topic}/channel4"
   white_value_scale: 100
-  effect_command_topic: "cmnd/{base_topic}/{topic}/Scheme"
-  effect_state_topic: "stat/{base_topic}/{topic}/RESULT"
+  effect_command_topic: "cmnd/{topic}/Scheme"
+  effect_state_topic: "stat/{topic}/RESULT"
   state_value_template: >
     {{% if "POWER" in value_json %}}
       {{{{ value_json.POWER }}}}

--- a/hass_templates/pow.py
+++ b/hass_templates/pow.py
@@ -5,10 +5,10 @@ import generic
 
 switch = """- platform: mqtt
   name: '{f_name}'
-  state_topic: 'stat/{base_topic}/{topic}/POWER'
-  command_topic: 'cmnd/{base_topic}/{topic}/POWER'
-  json_attributes_topic: 'tele/{base_topic}/{topic}/STATE'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  state_topic: 'stat/{topic}/POWER'
+  command_topic: 'cmnd/{topic}/POWER'
+  json_attributes_topic: 'tele/{topic}/STATE'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
   payload_on: 'ON'
@@ -21,109 +21,109 @@ sensor = generic.generic_telemetry + """    {name}_power:
 
 - platform: mqtt
   name: '{f_name} Total Start Time'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   value_template: '{{{{ value_json[\"ENERGY\"][\"TotalStartTime\"] }}}}'
   force_update: True
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 
 - platform: mqtt
   name: '{f_name} Total Energy'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   value_template: '{{{{ value_json[\"ENERGY\"][\"Total\"] }}}}'
   force_update: True
   unit_of_measurement: 'kilowatt hours'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 
 - platform: mqtt
   name: '{f_name} Energy Use Yesterday'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   value_template: '{{{{ value_json[\"ENERGY\"][\"Yesterday\"] }}}}'
   force_update: True
   unit_of_measurement: 'kilowatt hours'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 
 - platform: mqtt
   name: '{f_name} Energy Use Today'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   value_template: '{{{{ value_json[\"ENERGY\"][\"Today\"] }}}}'
   force_update: True
   unit_of_measurement: 'kilowatt hours'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 
 - platform: mqtt
   name: '{f_name} Energy Use Delta'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   value_template: '{{{{ value_json[\"ENERGY\"][\"Period\"] }}}}'
   force_update: True
   unit_of_measurement: 'Watt hours'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 
 - platform: mqtt
   name: '{f_name} Power Draw'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   value_template: '{{{{ value_json[\"ENERGY\"][\"Power\"] }}}}'
   force_update: True
   unit_of_measurement: 'Watts'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 
 - platform: mqtt
   name: '{f_name} Apparent Power Draw'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   value_template: '{{{{ value_json[\"ENERGY\"][\"ApparentPower\"] }}}}'
   force_update: True
   unit_of_measurement: 'Watts'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 
 - platform: mqtt
   name: '{f_name} Reactive Power Draw'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   value_template: '{{{{ value_json[\"ENERGY\"][\"ReactivePower\"] }}}}'
   force_update: True
   unit_of_measurement: 'Watts'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 
 - platform: mqtt
   name: '{f_name} Power Factor'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   value_template: '{{{{ value_json[\"ENERGY\"][\"Factor\"] }}}}'
   force_update: True
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 
 - platform: mqtt
   name: '{f_name} Voltage'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   value_template: '{{{{ value_json[\"ENERGY\"][\"Voltage\"] }}}}'
   force_update: True
   unit_of_measurement: 'Volts'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 
 - platform: mqtt
   name: '{f_name} Current'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   value_template: '{{{{ value_json[\"ENERGY\"][\"Current\"] }}}}'
   force_update: True
   unit_of_measurement: 'Amps'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 

--- a/hass_templates/sensor_cluster.py
+++ b/hass_templates/sensor_cluster.py
@@ -5,41 +5,41 @@ import generic
 
 sensor_cluster = """- platform: mqtt
   name: '{f_name} Temperature'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   unit_of_measurement: '°C'
   value_template: "{{{{ value_json['BME280']['Temperature'] }}}}"
   force_update: True
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 
 - platform: mqtt
   name: '{f_name} Pressure'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   unit_of_measurement: 'hPa'
   value_template: "{{{{ value_json['BME280']['Pressure'] }}}}"
   force_update: True
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 
 - platform: mqtt
   name: '{f_name} Humidity'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   unit_of_measurement: '%'
   value_template: "{{{{ value_json['BME280']['Humidity'] }}}}"
   force_update: True
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 
 - platform: mqtt
   name: '{f_name} Lux'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   unit_of_measurement: 'lux'
   value_template: "{{{{ value_json['BH1750']['Illuminance'] }}}}"
   force_update: True
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 

--- a/hass_templates/sump_pump.py
+++ b/hass_templates/sump_pump.py
@@ -4,11 +4,11 @@ import generic
 
 sensor_cluster = """- platform: mqtt
   name: '{f_name} Distance'
-  state_topic: 'tele/{base_topic}/{topic}/SENSOR'
+  state_topic: 'tele/{topic}/SENSOR'
   unit_of_measurement: 'cm'
   value_template: "{{{{ value_json['SR04']['Distance'] }}}}"
   force_update: True
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
 

--- a/hass_templates/switch.py
+++ b/hass_templates/switch.py
@@ -5,10 +5,10 @@ import generic
 
 switch = """- platform: mqtt
   name: '{f_name}'
-  state_topic: 'stat/{base_topic}/{topic}/POWER'
-  command_topic: 'cmnd/{base_topic}/{topic}/POWER'
-  json_attributes_topic: 'tele/{base_topic}/{topic}/STATE'
-  availability_topic: 'tele/{base_topic}/{topic}/LWT'
+  state_topic: 'stat/{topic}/POWER'
+  command_topic: 'cmnd/{topic}/POWER'
+  json_attributes_topic: 'tele/{topic}/STATE'
+  availability_topic: 'tele/{topic}/LWT'
   payload_available: 'Online'
   payload_not_available: 'Offline'
   payload_on: 'ON'


### PR DESCRIPTION
At some point we made base_topic optional, and the device init puts it into topic
if it exists.
This means base topic should not be used in templates.
